### PR TITLE
PHP向けミニマム実装

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+
+jobs:
+  build:
+    working_directory: ~/zengin-php
+    docker:
+      - image: circleci/php:latest
+    steps:
+      - checkout
+      - run: sudo composer self-update
+      - run: composer install -n --prefer-dist
+      - run:
+          name: phpunit
+          command: ./vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/*
+/composer.lock
+/vendor/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "source-data"]
+	path = source-data
+	url = git@github.com:zengin-code/source-data.git

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # zengin-php
 The ruby implementation of ZenginCode.
+
+## Installation
+Install via [composer](https://getcomposer.org/).
+
+```
+$ composer require zengin-code/zengin-php
+```
+
+## Usage
+```php
+// get source data updated at
+echo \ZenginCode\ZenginCode::getLastUpdatedAt(); // 20190501
+
+// get all banks as Bank instance array 
+$banks = \ZenginCode\ZenginCode::findBank();
+
+// find bank from code as Bank instance
+$bank = \ZenginCode\ZenginCode::findBank('0005');
+echo $bank->code . PHP_EOL; // 0005
+echo $bank->name . PHP_EOL; // 三菱ＵＦＪ
+echo $bank->kana . PHP_EOL; // ミツビシユ－エフジエイ
+echo $bank->hira . PHP_EOL; // みつびしゆ－えふじえい
+echo $bank->roma . PHP_EOL; // mitsubishiyu-efujiei
+
+// get all branches of bank as Branch instance array 
+$branches = \ZenginCode\ZenginCode::findBranch();
+
+// find branch from code as Branch instance
+$branch = \ZenginCode\ZenginCode::findBranch('0005', '002');
+echo $branch->code . PHP_EOL; // 002
+echo $branch->name . PHP_EOL; // 丸の内
+echo $branch->kana . PHP_EOL; // マルノウチ
+echo $branch->hira . PHP_EOL; // まるのうち
+echo $branch->roma . PHP_EOL; // marunouchi
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # zengin-php
-The ruby implementation of ZenginCode.
+The PHP implementation of ZenginCode.
 
 ## Installation
 Install via [composer](https://getcomposer.org/).

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "zengin-code/zengin-php",
+  "description": "bank codes and branch codes for Japanese",
+  "keywords": ["bank code"],
+  "homepage": "https://github.com/thatblue/zengin-php",
+  "license": "MIT",
+  "require": {
+    "php": ">= 5.5",
+    "guzzlehttp/guzzle": "^6.3"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^7.5 || ^4.8",
+    "php-coveralls/php-coveralls": "^2.1 || ^1.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "ZenginCode\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "ZenginCode\\": "tests/"
+    }
+  }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="zengin-php">
+            <directory>tests/ZenginCode/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+
+    <php>
+        <const name="PHPUNIT_TESTSUITE" value="true"/>
+    </php>
+</phpunit>

--- a/src/Model/Bank.php
+++ b/src/Model/Bank.php
@@ -1,0 +1,25 @@
+<?php
+namespace ZenginCode\Model;
+
+/**
+ * Class Bank
+ *
+ * @package ZenginCode\Model
+ */
+class Bank
+{
+    public $code = null;
+    public $name = null;
+    public $kana = null;
+    public $hira = null;
+    public $roma = null;
+
+    public function __construct($sourceJson)
+    {
+        $this->code = $sourceJson['code'];
+        $this->name = $sourceJson['name'];
+        $this->kana = $sourceJson['kana'];
+        $this->hira = $sourceJson['hira'];
+        $this->roma = $sourceJson['roma'];
+    }
+}

--- a/src/Model/Branch.php
+++ b/src/Model/Branch.php
@@ -1,0 +1,25 @@
+<?php
+namespace ZenginCode\Model;
+
+/**
+ * Class Branch
+ *
+ * @package ZenginCode\Model
+ */
+class Branch
+{
+    public $code = null;
+    public $name = null;
+    public $kana = null;
+    public $hira = null;
+    public $roma = null;
+
+    public function __construct($sourceJson)
+    {
+        $this->code = $sourceJson['code'];
+        $this->name = $sourceJson['name'];
+        $this->kana = $sourceJson['kana'];
+        $this->hira = $sourceJson['hira'];
+        $this->roma = $sourceJson['roma'];
+    }
+}

--- a/src/ZenginCode.php
+++ b/src/ZenginCode.php
@@ -1,0 +1,103 @@
+<?php
+namespace ZenginCode;
+
+use ZenginCode\Model\Bank;
+use ZenginCode\Model\Branch;
+
+class ZenginCode
+{
+    protected static $_version = null;
+    protected static $_banks = [];
+    protected static $_branches = [];
+
+    const DATA_PATH = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'source-data' . DIRECTORY_SEPARATOR . 'data';
+    const DIGIT_BANK_CODE = 4;
+    const DIGIT_BRANCH_CODE = 3;
+
+    /**
+     * get Last Updated date.
+     *
+     * @return string updated_at (YYYYMMDD style)
+     */
+    public static function getLastUpdatedAt()
+    {
+        if(!static::$_version) {
+            static::$_version = file_get_contents(ZenginCode::DATA_PATH . DIRECTORY_SEPARATOR . 'updated_at');
+        }
+
+        return static::$_version;
+    }
+
+    /**
+     * load source file
+     * NOTICE: USE ONLY INTERNAL CALL (this method not verify path)
+     *
+     * @param $path
+     * @return array
+     */
+    protected static function loadSourceFile($path)
+    {
+        if(!is_file(static::DATA_PATH . DIRECTORY_SEPARATOR . $path)) {
+            return null;
+        }
+
+        $fileContent = file_get_contents(static::DATA_PATH . DIRECTORY_SEPARATOR . $path);
+        return $fileContent !== false ? \GuzzleHttp\json_decode($fileContent, true) : null;
+    }
+
+    protected static function normalizeCode($rawCode, $digit)
+    {
+        return is_int($rawCode) ? sprintf('%0' . $digit . 'd', $rawCode) : (string)$rawCode;
+    }
+
+    /**
+     * find bank instance of specified code.
+     *
+     * if you not specified bank code, return all bank instances
+     *
+     * @param null $bankCode
+     * @return null|Bank|Bank[]
+     */
+    public static function findBank($bankCode = null)
+    {
+        if(!static::$_banks) {
+            $jsonBanks = static::loadSourceFile('banks.json');
+            foreach ($jsonBanks as $jsonBank) {
+                static::$_banks[$jsonBank['code']] = new Bank($jsonBank);
+            }
+        }
+
+        if($bankCode === null) {
+            return static::$_banks;
+        }
+
+        $bankCode = static::normalizeCode($bankCode, static::DIGIT_BANK_CODE);
+
+        return isset(static::$_banks[$bankCode]) ? static::$_banks[$bankCode] : null;
+    }
+
+    public static function findBranch($bankCode, $branchCode = null)
+    {
+        $bankCode = static::normalizeCode($bankCode, static::DIGIT_BANK_CODE);
+
+        if(!isset(static::$_branches[$bankCode])) {
+            $jsonBranches = static::loadSourceFile('branches' . DIRECTORY_SEPARATOR . $bankCode . '.json');
+            if($jsonBranches) {
+                $branches = [];
+                foreach ($jsonBranches as $jsonBranch) {
+                    $branches[$jsonBranch['code']] = new Branch($jsonBranch);
+                }
+
+                static::$_branches[$bankCode] = $branches;
+            }
+        }
+
+        if($branchCode === null) {
+            return static::$_branches[$bankCode];
+        }
+
+        $branchCode = static::normalizeCode($branchCode, static::DIGIT_BRANCH_CODE);
+
+        return isset(static::$_branches[$bankCode][$branchCode]) ? static::$_branches[$bankCode][$branchCode] : null;
+    }
+}

--- a/tests/ZenginCode/ZenginCodeTest.php
+++ b/tests/ZenginCode/ZenginCodeTest.php
@@ -1,0 +1,113 @@
+<?php
+namespace ZenginCode;
+
+use PHPUnit\Framework\TestCase;
+
+class ZenginCodeTest extends TestCase
+{
+    public function test_getLastUpdatedAt()
+    {
+        $this->assertSame(
+            file_get_contents(ZenginCode::DATA_PATH . DIRECTORY_SEPARATOR . 'updated_at'),
+            ZenginCode::getLastUpdatedAt()
+        );
+    }
+
+    public function test_findBank_existsCode()
+    {
+        $actualBank = ZenginCode::findBank('0001');
+
+        $this->assertSame('0001', $actualBank->code);
+        $this->assertSame('みずほ', $actualBank->name);
+        $this->assertSame('ミズホ', $actualBank->kana);
+        $this->assertSame('みずほ', $actualBank->hira);
+        $this->assertSame('mizuho', $actualBank->roma);
+    }
+
+    public function test_findBank_notExistsCode()
+    {
+        $this->assertNull(ZenginCode::findBank('9999'));
+    }
+
+    public function test_findBank_intCode()
+    {
+        $actualBank = ZenginCode::findBank(125);
+
+        $this->assertSame('0125', $actualBank->code);
+        $this->assertSame('七十七', $actualBank->name);
+        $this->assertSame('シチジユウシチ', $actualBank->kana);
+        $this->assertSame('しちじゆうしち', $actualBank->hira);
+        $this->assertSame('shichijiyuushichi', $actualBank->roma);
+    }
+
+    public function test_findBank_all()
+    {
+        $banks = ZenginCode::findBank();
+
+        $this->assertIsArray($banks);
+        foreach ($banks as $bank) {
+            $this->assertInstanceOf('ZenginCode\Model\Bank', $bank);
+        }
+   }
+
+   public function test_findBranch_existsCode()
+   {
+       $actualBranch = ZenginCode::findBranch('0001', '001');
+       $this->assertSame('001', $actualBranch->code);
+       $this->assertSame('東京営業部', $actualBranch->name);
+       $this->assertSame('トウキヨウ', $actualBranch->kana);
+       $this->assertSame('とうきよう', $actualBranch->hira);
+       $this->assertSame('toukiyou', $actualBranch->roma);
+   }
+
+    /**
+     * @depends test_findBranch_existsCode
+     */
+    public function test_findBranch_anotherExistsCode()
+    {
+        $actualBranch = ZenginCode::findBranch('0005', '001');
+        $this->assertSame('001', $actualBranch->code);
+        $this->assertSame('本店', $actualBranch->name);
+        $this->assertSame('ホンテン', $actualBranch->kana);
+        $this->assertSame('ほんてん', $actualBranch->hira);
+        $this->assertSame('honten', $actualBranch->roma);
+    }
+
+    /**
+     * @depends test_findBranch_anotherExistsCode
+     */
+    public function test_findBranch_recallFirstExitsCode()
+    {
+        $actualBranch = ZenginCode::findBranch('0001', '001');
+        $this->assertSame('001', $actualBranch->code);
+        $this->assertSame('東京営業部', $actualBranch->name);
+        $this->assertSame('トウキヨウ', $actualBranch->kana);
+        $this->assertSame('とうきよう', $actualBranch->hira);
+        $this->assertSame('toukiyou', $actualBranch->roma);
+    }
+
+    public function test_findBranch_notExistsCode()
+    {
+        $this->assertNull(ZenginCode::findBranch('0001', '999'));
+    }
+
+    public function test_findBranch_notExistsBank()
+    {
+        try {
+            $this->assertNull(ZenginCode::findBranch('9999', '001'));
+        } catch (\Throwable $t) {
+            $this->fail();
+        }
+    }
+
+    public function test_findBranch_all()
+    {
+        $branches = ZenginCode::findBranch('0001');
+
+        $this->assertIsArray($branches);
+        foreach ($branches as $branch) {
+            $this->assertInstanceOf('ZenginCode\Model\Branch', $branch);
+        }
+    }
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+error_reporting(E_ALL);
+
+require_once 'vendor/autoload.php';


### PR DESCRIPTION
銀行コードデータのメンテナンスありがとうございます。
プログラムから使いやすい形でまとめられているデータは多くないのでとても助かります:pray:

最小限かつ簡単なコードなのですが、PHP向けの実装を作ってみました。
利用方法についてはreadmeに記載のとおりです。
composer.jsonはpackagistへ`zengin-code/zengin-php`で登録する想定で記載しています。

問題点などありましたらご指摘いただければ助かります。
どうぞよろしくお願いいたします。